### PR TITLE
Add active, visible, and collidable FlagToggleModifier options

### DIFF
--- a/Ahorn/entities/entityContainers.jl
+++ b/Ahorn/entities/entityContainers.jl
@@ -31,7 +31,7 @@ using ..Ahorn, Maple, Ahorn.Selection
 
 @mapdef Entity "EeveeHelper/FlagToggleModifier" FlagToggleModifier(x::Integer, y::Integer, width::Integer=8, height::Integer=8,
     whitelist::String="", blacklist::String="", containMode::String="RoomStart", containFlag::String="", forceStandardBehavior::Bool=false,
-    flag::String="")
+    flag::String="", notFlag::Bool=false, toggleActive::Bool=true, toggleVisible::Bool=true, toggleCollidable::Bool=true)
 @mapdef Entity "EeveeHelper/CollidableModifier" CollidableModifier(x::Integer, y::Integer, width::Integer=8, height::Integer=8,
     whitelist::String="", blacklist::String="", containMode::String="RoomStart", containFlag::String="", forceStandardBehavior::Bool=false,
     noCollide::Bool=false, solidify::Bool=false)

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -114,6 +114,10 @@ placements.entities.EeveeHelper/FlagGateContainer.tooltips.iconVisible=Whether t
 
 # Flag Toggle Modifier
 placements.entities.EeveeHelper/FlagToggleModifier.tooltips.flag=Flag that toggles whether the modified entities are active. Empty for always active. (Prefix flag name with "!" to invert, e.g. !myFlag)
+placements.entities.EeveeHelper/FlagToggleModifier.tooltips.notFlag=Inverts the flag requirement for toggling entities. If enabled and no flag is specified, entities will always be disabled.
+placements.entities.EeveeHelper/FlagToggleModifier.tooltips.toggleActive=Controls whether toggling will affect if entities update (move/act on their own).
+placements.entities.EeveeHelper/FlagToggleModifier.tooltips.toggleVisible=Controls whether toggling will affect if entities are visible.
+placements.entities.EeveeHelper/FlagToggleModifier.tooltips.toggleCollidable=Controls whether toggling will affect if entities are collidable.
 
 # Collidable Modifier
 placements.entities.EeveeHelper/CollidableModifier.tooltips.noCollide=Disables collision for the modified entities.

--- a/Code/Handlers/IToggleable.cs
+++ b/Code/Handlers/IToggleable.cs
@@ -8,8 +8,8 @@ namespace Celeste.Mod.EeveeHelper.Handlers {
     public interface IToggleable {
         object SaveState();
 
-        void ReadState(object state);
+        void ReadState(object state, bool toggleActive, bool toggleVisible, bool toggleCollidable);
 
-        void Disable();
+        void Disable(bool toggleActive, bool toggleVisible, bool toggleCollidable);
     }
 }

--- a/Loenn/entities/entityContainers.lua
+++ b/Loenn/entities/entityContainers.lua
@@ -205,6 +205,10 @@ local flagToggleModifier = {
             containFlag = "",
             forceStandardBehavior = false,
             flag = "",
+            notFlag = false,
+            toggleActive = true,
+            toggleVisible = true,
+            toggleCollidable = true,
         }
     }
 }

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -129,6 +129,10 @@ entities.EeveeHelper/FlagGateContainer.attributes.description.iconVisible=Whethe
 
 # Flag Toggle Modifier
 entities.EeveeHelper/FlagToggleModifier.attributes.description.flag=Flag that toggles whether the modified entities are active. Empty for always active. (Prefix flag name with "!" to invert, e.g. !myFlag)
+entities.EeveeHelper/FlagToggleModifier.attributes.description.notFlag=Inverts the flag requirement for toggling entities. If enabled and no flag is specified, entities will always be disabled.
+entities.EeveeHelper/FlagToggleModifier.attributes.description.toggleActive=Controls whether toggling will affect if entities update (move/act on their own).
+entities.EeveeHelper/FlagToggleModifier.attributes.description.toggleVisible=Controls whether toggling will affect if entities are visible.
+entities.EeveeHelper/FlagToggleModifier.attributes.description.toggleCollidable=Controls whether toggling will affect if entities are collidable.
 
 # Collidable Modifier
 entities.EeveeHelper/CollidableModifier.attributes.description.noCollide=Disables collision for the modified entities.


### PR DESCRIPTION
i added `toggleActive`, `toggleVisible`, and `toggleCollidable` options to the FlagToggleModifier. i also added a `notFlag` toggle for convenience to make entities always disabled without specifying a flag

this is just a minor thing i did for fun - i was going to make a VisibleModifier similar to CollidableModifier (i cant believe i didnt????) but just adding options for the FlagToggleModifier works a lot better for compatibility / customizability

(thanks for maintaining EeveeHelper btw)