### PR TITLE
Many SMW Platform/Container additions

### DIFF
--- a/Ahorn/entities/entityContainers.jl
+++ b/Ahorn/entities/entityContainers.jl
@@ -20,8 +20,9 @@ using ..Ahorn, Maple, Ahorn.Selection
 @mapdef Entity "EeveeHelper/SMWTrackContainer" SMWTrackContainer(x::Integer, y::Integer, width::Integer=8, height::Integer=8,
     whitelist::String="", blacklist::String="", containMode::String="RoomStart", containFlag::String="",
     fitContained::Bool=true, ignoreAnchors::Bool=false, forceStandardBehavior::Bool=false,
-    moveSpeed::Number=100.0, fallSpeed::Number=200.0, gravity::Number=200.0, direction::String="Right", moveFlag::String="", startOnTouch::Bool=false,
-    disableBoost::Bool=false)
+    moveSpeed::Number=100.0, fallSpeed::Number=200.0, gravity::Number=200.0, startDelay::Number=0.0, direction::String="Right", moveFlag::String="",
+    moveBehaviour::String="Linear", easing::String="SineInOut", easeDuration::Number=2.0, easeTrackDirection::Bool=false, startOnTouch::Bool=false,
+    stopAtNode::Bool=false, stopAtEnd::Bool=false, moveOnce::Bool=false, disableBoost::Bool=false)
 @mapdef Entity "EeveeHelper/FlagGateContainer" FlagGateContainer(x::Integer, y::Integer, width::Integer=8, height::Integer=8,
     whitelist::String="", blacklist::String="", containMode::String="RoomStart", containFlag::String="",
     fitContained::Bool=true, ignoreAnchors::Bool=false, forceStandardBehavior::Bool=false,
@@ -154,6 +155,7 @@ Ahorn.editingOrder(entity::FloatyContainer) = ["x", "y", "width", "height", "con
 const containModeOptions = ["RoomStart", "FlagChanged", "Always"]
 
 const easeTypes = ["Linear", "SineIn", "SineOut", "SineInOut", "QuadIn", "QuadOut", "QuadInOut", "CubeIn", "CubeOut", "CubeInOut", "QuintIn", "QuintOut", "QuintInOut", "BackIn", "BackOut", "BackInOut", "ExpoIn", "ExpoOut", "ExpoInOut", "BigBackIn", "BigBackOut", "BigBackInOut", "ElasticIn", "ElasticOut", "ElasticInOut", "BounceIn", "BounceOut", "BounceInOut"]
+const easeTypesReversible = ["Linear", "SineIn", "SineOut", "SineInOut", "QuadIn", "QuadOut", "QuadInOut", "CubeIn", "CubeOut", "CubeInOut", "QuintIn", "QuintOut", "QuintInOut", "ExpoIn", "ExpoOut", "ExpoInOut"]
 
 Ahorn.editingOptions(entity::containerUnion) = Dict{String, Any}(
     "containMode" => containModeOptions
@@ -164,7 +166,9 @@ Ahorn.editingOptions(entity::AttachedContainer) = Dict{String, Any}(
 )
 Ahorn.editingOptions(entity::SMWTrackContainer) = Dict{String, Any}(
     "containMode" => containModeOptions,
-    "direction" => ["Left", "Right"]
+    "direction" => ["Left", "Right"],
+    "moveBehaviour" => ["Linear", "Easing"],
+    "easing" => easeTypesReversible
 )
 Ahorn.editingOptions(entity::FlagGateContainer) = Dict{String, Any}(
     "containMode" => containModeOptions,

--- a/Ahorn/entities/smwPlatform.jl
+++ b/Ahorn/entities/smwPlatform.jl
@@ -3,8 +3,9 @@ module EeveeHelperSMWPlatform
 using ..Ahorn, Maple
 
 @mapdef Entity "EeveeHelper/SMWPlatform" SMWPlatform(x::Integer, y::Integer, width::Integer=40, height::Integer=8, texturePath::String="objects/EeveeHelper/smwPlatform",
-    moveSpeed::Number=100.0, fallSpeed::Number=200.0, gravity::Number=200.0, direction::String="Right", flag::String="", notFlag::Bool=false, startOnTouch::Bool=true,
-    disableBoost::Bool=false)
+    moveSpeed::Number=100.0, fallSpeed::Number=200.0, gravity::Number=200.0, startDelay::Number=0.0, direction::String="Right", flag::String="",
+    moveBehaviour::String="Linear", easing::String="SineInOut", easeDuration::Number=2.0, easeTrackDirection::Bool=false, notFlag::Bool=false, startOnTouch::Bool=true,
+    stopAtNode::Bool=false, stopAtEnd::Bool=false, moveOnce::Bool=false, disableBoost::Bool=false)
 
 const placements = Ahorn.PlacementDict(
     "SMW Platform (Eevee Helper)" => Ahorn.EntityPlacement(
@@ -17,7 +18,9 @@ Ahorn.minimumSize(entity::SMWPlatform) = 16, 0
 Ahorn.resizable(entity::SMWPlatform) = true, false
 
 Ahorn.editingOptions(entity::SMWPlatform) = Dict{String, Any}(
-    "direction" => ["Left", "Right"]
+    "direction" => ["Left", "Right"],
+    "moveBehaviour" => ["Linear", "Easing"],
+    "easing" => ["Linear", "SineIn", "SineOut", "SineInOut", "QuadIn", "QuadOut", "QuadInOut", "CubeIn", "CubeOut", "CubeInOut", "QuintIn", "QuintOut", "QuintInOut", "ExpoIn", "ExpoOut", "ExpoInOut"]
 )
 
 function Ahorn.selection(entity::SMWPlatform)

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -96,6 +96,14 @@ placements.entities.EeveeHelper/SMWTrackContainer.tooltips.moveSpeed=Speed at wh
 placements.entities.EeveeHelper/SMWTrackContainer.tooltips.direction=Initial direction the container moves along its track.
 placements.entities.EeveeHelper/SMWTrackContainer.tooltips.disableBoost=Disables horizontal boost from track movement.
 placements.entities.EeveeHelper/SMWTrackContainer.tooltips.startOnTouch=Makes the container only start moving when the player touches a contained entity.
+placements.entities.EeveeHelper/SMWTrackContainer.tooltips.moveBehaviour=Whether the container moves along the track linearly or with easing.
+placements.entities.EeveeHelper/SMWTrackContainer.tooltips.easing=The easing of the container's movement along the track, if move behaviour is Easing.
+placements.entities.EeveeHelper/SMWTrackContainer.tooltips.easeDuration=How long the container takes to ease along the track.
+placements.entities.EeveeHelper/SMWTrackContainer.tooltips.easeTrackDirection=Whether the track's direction should affect the easing. If enabled, the container will smoothly "bounce back" when it reaches the end of the track.
+placements.entities.EeveeHelper/SMWTrackContainer.tooltips.stopAtNode=Whether the container should stop moving when it reaches a node on the track.
+placements.entities.EeveeHelper/SMWTrackContainer.tooltips.stopAtEnd=Whether the container should stop moving when it reaches the end of the track. (Always enabled if Stop At Node is enabled)
+placements.entities.EeveeHelper/SMWTrackContainer.tooltips.moveOnce=Whether the container can be re-activated after reaching the end of the track. (Only if Stop At Node/End is enabled)
+placements.entities.EeveeHelper/SMWTrackContainer.tooltips.startDelay=The delay before the container starts moving when activated. Only applies if the container needs to be started with a touch/flag.
 
 # Flag Gate Container
 placements.entities.EeveeHelper/FlagGateContainer.tooltips.fitContained=Whether the container's box is resized if entities inside it move.
@@ -146,6 +154,14 @@ placements.entities.EeveeHelper/SMWPlatform.tooltips.direction=Initial direction
 placements.entities.EeveeHelper/SMWPlatform.tooltips.disableBoost=Disables horizontal boost from track movement.
 placements.entities.EeveeHelper/SMWPlatform.tooltips.notFlag=Inverts the flag requirement for the platform to move.
 placements.entities.EeveeHelper/SMWPlatform.tooltips.startOnTouch=Makes the platform only start moving when the player touches it.
+placements.entities.EeveeHelper/SMWPlatform.tooltips.moveBehaviour=Whether the platform moves along the track linearly or with easing.
+placements.entities.EeveeHelper/SMWPlatform.tooltips.easing=The easing of the platform's movement along the track, if move behaviour is Easing.
+placements.entities.EeveeHelper/SMWPlatform.tooltips.easeDuration=How long the platform takes to ease along the track.
+placements.entities.EeveeHelper/SMWPlatform.tooltips.easeTrackDirection=Whether the track's direction should affect the easing. If enabled, the platform will smoothly "bounce back" when it reaches the end of the track.
+placements.entities.EeveeHelper/SMWPlatform.tooltips.stopAtNode=Whether the platform should stop moving when it reaches a node on the track.
+placements.entities.EeveeHelper/SMWPlatform.tooltips.stopAtEnd=Whether the platform should stop moving when it reaches the end of the track. (Always enabled if Stop At Node is enabled)
+placements.entities.EeveeHelper/SMWPlatform.tooltips.moveOnce=Whether the platform can be re-activated after reaching the end of the track. (Only if Stop At Node/End is enabled)
+placements.entities.EeveeHelper/SMWPlatform.tooltips.startDelay=The delay before the platform starts moving when activated. Only applies if the platform needs to be started with a touch/flag.
 
 # Room Chest
 placements.entities.EeveeHelper/RoomChest.tooltips.room=Name of the room this chest should take you to.

--- a/Code/Entities/Containers/SMWTrackContainer.cs
+++ b/Code/Entities/Containers/SMWTrackContainer.cs
@@ -16,6 +16,7 @@ namespace Celeste.Mod.EeveeHelper.Entities {
         private string moveFlag;
         private bool notFlag;
         private bool startOnTouch;
+        private bool stopAtNode;
         private bool stopAtEnd;
         private bool once;
         private bool disableBoost;
@@ -43,6 +44,7 @@ namespace Celeste.Mod.EeveeHelper.Entities {
             }
             startOnTouch = data.Bool("startOnTouch");
             disableBoost = data.Bool("disableBoost");
+            stopAtNode = data.Bool("stopAtNode");
             stopAtEnd = data.Bool("stopAtEnd");
             once = data.Bool("moveOnce");
             startDelay = data.Float("startDelay");
@@ -52,17 +54,18 @@ namespace Celeste.Mod.EeveeHelper.Entities {
             });
 
             Add(Mover = new SMWTrackMover(data) {
+                StopAtNode = stopAtNode,
                 StopAtEnd = stopAtEnd,
 
                 GetPosition = () => Center,
                 SetPosition = (pos, move) => _Container.DoMoveAction(() => Center = pos, (h, delta) => EeveeUtils.GetTrackBoost(move, disableBoost)),
 
-                OnEnd = (mover, direction) => {
-                    if (stopAtEnd) {
-                        if (startOnTouch) {
-                            started = false;
-                        }
-                        waitingForRestart = true;
+                OnStop = (mover, end) => {
+                    if (startOnTouch) {
+                        started = false;
+                    }
+                    waitingForRestart = true;
+                    if (end) {
                         movedOnce = true;
                     }
                 }
@@ -80,7 +83,7 @@ namespace Celeste.Mod.EeveeHelper.Entities {
             base.Awake(scene);
 
             // If the platform is active on spawn, skip the start delay
-            if (CheckStarted())
+            if (!startOnTouch && CheckStarted())
                 startTimer = startDelay;
         }
 

--- a/Code/Entities/SMWPlatform.cs
+++ b/Code/Entities/SMWPlatform.cs
@@ -14,6 +14,7 @@ namespace Celeste.Mod.EeveeHelper.Entities {
         private string flag;
         private bool notFlag;
         private bool startOnTouch;
+        private bool stopAtNode;
         private bool stopAtEnd;
         private bool once;
         private bool disableBoost;
@@ -36,12 +37,14 @@ namespace Celeste.Mod.EeveeHelper.Entities {
             flag = data.Attr("flag");
             notFlag = data.Bool("notFlag");
             startOnTouch = data.Bool("startOnTouch");
+            stopAtNode = data.Bool("stopAtNode");
             stopAtEnd = data.Bool("stopAtEnd");
             once = data.Bool("moveOnce");
             disableBoost = data.Bool("disableBoost");
             startDelay = data.Float("startDelay");
 
             Add(Mover = new SMWTrackMover(data) {
+                StopAtNode = stopAtNode,
                 StopAtEnd = stopAtEnd,
 
                 GetPosition = () => ExactPosition,
@@ -50,14 +53,14 @@ namespace Celeste.Mod.EeveeHelper.Entities {
                     MoveTo(pos, EeveeUtils.GetTrackBoost(move, disableBoost));
                 },
 
-                OnEnd = (mover, direction) => {
-                    if (stopAtEnd) {
-                        if (startOnTouch) {
-                            started = false;
-                        }
-                        movedOnce = true;
-                        waitingForRestart = true;
+                OnStop = (mover, end) => {
+                    if (startOnTouch) {
+                        started = false;
                     }
+                    if (end) {
+                        movedOnce = true;
+                    }
+                    waitingForRestart = true;
                 }
             });
 
@@ -90,7 +93,7 @@ namespace Celeste.Mod.EeveeHelper.Entities {
             base.Awake(scene);
 
             // If the platform is active on spawn, skip the start delay
-            if (CheckStarted())
+            if (!startOnTouch && CheckStarted())
                 startTimer = startDelay;
         }
 

--- a/Code/ReverseEase.cs
+++ b/Code/ReverseEase.cs
@@ -1,0 +1,57 @@
+﻿using Monocle;
+using System;
+using System.Collections.Generic;
+
+namespace Celeste.Mod.EeveeHelper {
+    public static class ReverseEase {
+        public static Ease.Easer Linear = (float t) => t;
+
+        public static Ease.Easer SineIn = (float t) => 2 * (float)Math.Acos(1 - t) / (float)Math.PI;
+        public static Ease.Easer SineOut = (float t) => 2 * (float)Math.Asin(t) / (float)Math.PI;
+        public static Ease.Easer SineInOut = (float t) => 2 * (float)Math.Asin(Math.Sqrt(t)) / (float)Math.PI;
+
+        public static Ease.Easer QuadIn = (float t) => (float)Math.Sqrt(t);
+        public static Ease.Easer QuadOut = Ease.Invert(QuadIn);
+        public static Ease.Easer QuadInOut = Ease.Follow(QuadIn, QuadOut);
+
+        public static Ease.Easer CubeIn = (float t) => (float)Math.Pow(t, 1f / 3f);
+        public static Ease.Easer CubeOut = Ease.Invert(CubeIn);
+        public static Ease.Easer CubeInOut = Ease.Follow(CubeIn, CubeOut);
+
+        public static Ease.Easer QuintIn = (float t) => (float)Math.Pow(t, 1f / 5f);
+        public static Ease.Easer QuintOut = Ease.Invert(QuintIn);
+        public static Ease.Easer QuintInOut = Ease.Follow(QuintIn, QuintOut);
+
+        public static Ease.Easer ExpoIn = (float t) => (float)Math.Log(1024f * t) / (10f * (float)Math.Log(2f));
+        public static Ease.Easer ExpoOut = Ease.Invert(ExpoIn);
+        public static Ease.Easer ExpoInOut = Ease.Follow(ExpoIn, ExpoOut);
+
+        // there are no reverse easings for Back, BigBack, Elastic and Bounce
+
+        private static Dictionary<Ease.Easer, Ease.Easer> reverseEasings = new Dictionary<Ease.Easer, Ease.Easer>() {
+            { Ease.Linear, Linear },
+            { Ease.SineIn, SineIn },
+            { Ease.SineOut, SineOut },
+            { Ease.SineInOut, SineInOut },
+            { Ease.QuadIn, QuadIn },
+            { Ease.QuadOut, QuadOut },
+            { Ease.QuadInOut, QuadInOut },
+            { Ease.CubeIn, CubeIn },
+            { Ease.CubeOut, CubeOut },
+            { Ease.CubeInOut, CubeInOut },
+            { Ease.QuintIn, QuintIn },
+            { Ease.QuintOut, QuintOut },
+            { Ease.QuintInOut, QuintInOut },
+            { Ease.ExpoIn, ExpoIn },
+            { Ease.ExpoOut, ExpoOut },
+            { Ease.ExpoInOut, ExpoInOut }
+        };
+
+        public static Ease.Easer GetReverse(Ease.Easer ease) {
+            if (reverseEasings.TryGetValue(ease, out var result)) {
+                return result;
+            }
+            return Linear;
+        }
+    }
+}

--- a/Loenn/entities/entityContainers.lua
+++ b/Loenn/entities/entityContainers.lua
@@ -134,6 +134,7 @@ local SMWTrackContainer = {
                 easeDuration = 2.0,
                 easeTrackDirection = false,
                 startOnTouch = false,
+                stopAtNode = false,
                 stopAtEnd = false,
                 moveOnce = false,
                 disableBoost = false,

--- a/Loenn/entities/entityContainers.lua
+++ b/Loenn/entities/entityContainers.lua
@@ -112,26 +112,77 @@ local SMWTrackContainer = {
     borderColor = { 1.0, 0.6, 0.6, 1 },
 
     placements = {
-        name = "default",
-        data = {
-            width = 8,
-            height = 8,
-            whitelist = "",
-            blacklist = "",
-            containMode = "RoomStart",
-            containFlag = "",
-            fitContained = true,
-            ignoreAnchors = false,
-            forceStandardBehavior = false,
-            moveSpeed = 100.0,
-            fallSpeed = 200.0,
-            gravity = 200.0,
-            direction = "Right",
-            moveFlag = "",
-            startOnTouch = false,
-            disableBoost = false,
+        default = {
+            data = {
+                width = 8,
+                height = 8,
+                whitelist = "",
+                blacklist = "",
+                containMode = "RoomStart",
+                containFlag = "",
+                fitContained = true,
+                ignoreAnchors = false,
+                forceStandardBehavior = false,
+                moveSpeed = 100.0,
+                fallSpeed = 200.0,
+                gravity = 200.0,
+                startDelay = 0.0,
+                direction = "Right",
+                moveFlag = "",
+                moveBehaviour = "Linear",
+                easing = "SineInOut",
+                easeDuration = 2.0,
+                easeTrackDirection = false,
+                startOnTouch = false,
+                stopAtEnd = false,
+                moveOnce = false,
+                disableBoost = false,
+            }
+        },
+        {
+            name = "linear",
+            data = {
+                width = 40,
+                height = 8,
+                moveBehaviour = "Linear"
+            }
+        },
+        {
+            name = "easing",
+            data = {
+                width = 40,
+                height = 8,
+                moveBehaviour = "Easing"
+            }
         }
-    }
+    },
+
+    fieldInformation = {
+        easing = {
+            options = { "Linear", "SineIn", "SineOut", "SineInOut", "QuadIn", "QuadOut", "QuadInOut", "CubeIn", "CubeOut", "CubeInOut", "QuintIn", "QuintOut", "QuintInOut", "ExpoIn", "ExpoOut", "ExpoInOut" },
+            editable = false
+        },
+        moveBehaviour = {
+            options = { "Linear", "Easing" },
+            editable = false,
+        }
+    },
+
+    ignoredFields = function (entity)
+        local ignored = {"_name", "_id", "originX", "originY"}
+
+        if entity.moveBehaviour == "Linear" then
+            table.insert(ignored, "easing")
+            table.insert(ignored, "easeDuration")
+            table.insert(ignored, "easeTrackDirection")
+
+        elseif entity.moveBehaviour == "Easing" then
+            table.insert(ignored, "moveSpeed")
+
+        end
+
+        return ignored
+    end,
 }
 
 local flagGateContainer = {
@@ -311,7 +362,13 @@ local sharedFieldInformation = {
 }
 
 for _, container in ipairs(containers) do
-    container.fieldInformation = sharedFieldInformation
+    container.fieldInformation = container.fieldInformation or {}
+    for k, v in pairs(sharedFieldInformation) do
+        -- only add shared field information if it doesn't already exist
+        if container.fieldInformation[k] == nil then
+            container.fieldInformation[k] = v
+        end
+    end
     container.depth = math.huge -- make containers render below everything
 end
 

--- a/Loenn/entities/smwPlatform.lua
+++ b/Loenn/entities/smwPlatform.lua
@@ -25,6 +25,7 @@ local smwPlatform = {
                 easeTrackDirection = false,
                 notFlag = false,
                 startOnTouch = true,
+                stopAtNode = false,
                 stopAtEnd = false,
                 moveOnce = false,
                 disableBoost = false,

--- a/Loenn/entities/smwPlatform.lua
+++ b/Loenn/entities/smwPlatform.lua
@@ -8,19 +8,43 @@ local smwPlatform = {
     canResize = {true, false},
 
     placements = {
-        name = "default",
-        data = {
-            width = 40,
-            height = 8,
-            texturePath = "objects/EeveeHelper/smwPlatform",
-            moveSpeed = 100.0,
-            fallSpeed = 200.0,
-            gravity = 200.0,
-            direction = "Right",
-            flag = "",
-            notFlag = false,
-            startOnTouch = true,
-            disableBoost = false,
+        default = {
+            data = {
+                width = 40,
+                height = 8,
+                texturePath = "objects/EeveeHelper/smwPlatform",
+                moveSpeed = 100.0,
+                fallSpeed = 200.0,
+                gravity = 200.0,
+                startDelay = 0.0,
+                direction = "Right",
+                flag = "",
+                moveBehaviour = "Linear",
+                easing = "SineInOut",
+                easeDuration = 2.0,
+                easeTrackDirection = false,
+                notFlag = false,
+                startOnTouch = true,
+                stopAtEnd = false,
+                moveOnce = false,
+                disableBoost = false,
+            }
+        },
+        {
+            name = "linear",
+            data = {
+                width = 40,
+                height = 8,
+                moveBehaviour = "Linear"
+            }
+        },
+        {
+            name = "easing",
+            data = {
+                width = 40,
+                height = 8,
+                moveBehaviour = "Easing"
+            }
         }
     },
 
@@ -28,8 +52,32 @@ local smwPlatform = {
         direction = {
             options = { "Left", "Right" },
             editable = false,
+        },
+        moveBehaviour = {
+            options = { "Linear", "Easing" },
+            editable = false,
+        },
+        easing = {
+            options = { "Linear", "SineIn", "SineOut", "SineInOut", "QuadIn", "QuadOut", "QuadInOut", "CubeIn", "CubeOut", "CubeInOut", "QuintIn", "QuintOut", "QuintInOut", "ExpoIn", "ExpoOut", "ExpoInOut" },
+            editable = false
         }
     },
+
+    ignoredFields = function (entity)
+        local ignored = {"_name", "_id", "originX", "originY", "height"}
+
+        if entity.moveBehaviour == "Linear" then
+            table.insert(ignored, "easing")
+            table.insert(ignored, "easeDuration")
+            table.insert(ignored, "easeTrackDirection")
+
+        elseif entity.moveBehaviour == "Easing" then
+            table.insert(ignored, "moveSpeed")
+
+        end
+
+        return ignored
+    end,
 
     selection = function (room, entity)
         return utils.rectangle(entity.x - entity.width / 2, entity.y - 8, entity.width, 8)

--- a/Loenn/entities/smwTrack.lua
+++ b/Loenn/entities/smwTrack.lua
@@ -33,6 +33,7 @@ local smwTrack = {
 
     placements = {
         name = "default",
+        placementType = "line",
         data = {
             color = "FFFFFF",
             inactiveColor = "",

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -33,7 +33,8 @@ entities.EeveeHelper/FloatyContainer.attributes.description.blacklist=Comma-sepa
 entities.EeveeHelper/FloatyContainer.attributes.description.ignoreAnchors=Disables the movement of internal "anchor positions", which usually store the start position of the entity.
 entities.EeveeHelper/FloatyContainer.attributes.description.forceStandardBehavior=Disables new special-cased behaviour for entities. New special behaviour may be added at any time, so enable this option if you're taking advantage of any buggy/jank behaviour.
 
-entities.EeveeHelper/SMWTrackContainer.placements.name.default=SMW Track Container
+entities.EeveeHelper/SMWTrackContainer.placements.name.linear=SMW Track Container
+entities.EeveeHelper/SMWTrackContainer.placements.name.easing=SMW Track Container (Easing)
 entities.EeveeHelper/SMWTrackContainer.attributes.description.containMode=Determines how the container contains entities.\n - RoomStart: Whitelisted entities inside the container at the start of the room are the only entities that will be contained.\n - FlagChanged: Entities are re-contained whenever the flag is enabled. This means you can delay containment with a flag to contain something like the Player.\n - Always: Whitelisted entities inside the container are always affected, and entities outside the container are no longer affected.
 entities.EeveeHelper/SMWTrackContainer.attributes.description.containFlag=The container will only be enabled when the flag is active. Empty for always enabled. (Prefix flag name with "!" to invert, e.g. !myFlag)
 entities.EeveeHelper/SMWTrackContainer.attributes.description.whitelist=Comma-separated list of entity class names to contain (e.g. Booster,CrystalStaticSpinner,etc). Contains most entities if empty.
@@ -111,6 +112,13 @@ entities.EeveeHelper/SMWTrackContainer.attributes.description.moveSpeed=Speed at
 entities.EeveeHelper/SMWTrackContainer.attributes.description.direction=Initial direction the container moves along its track.
 entities.EeveeHelper/SMWTrackContainer.attributes.description.disableBoost=Disables horizontal boost from track movement.
 entities.EeveeHelper/SMWTrackContainer.attributes.description.startOnTouch=Makes the container only start moving when the player touches a contained entity.
+entities.EeveeHelper/SMWTrackContainer.attributes.description.moveBehaviour=Whether the container moves along the track linearly or with easing.
+entities.EeveeHelper/SMWTrackContainer.attributes.description.easing=The easing of the container's movement along the track, if move behaviour is Easing.
+entities.EeveeHelper/SMWTrackContainer.attributes.description.easeDuration=How long the container takes to ease along the track.
+entities.EeveeHelper/SMWTrackContainer.attributes.description.easeTrackDirection=Whether the track's direction should affect the easing. If enabled, the container will smoothly "bounce back" when it reaches the end of the track.
+entities.EeveeHelper/SMWTrackContainer.attributes.description.stopAtEnd=Whether the container should stop moving when it reaches the end of the track.
+entities.EeveeHelper/SMWTrackContainer.attributes.description.moveOnce=Whether the container can be re-activated after after stopping.
+entities.EeveeHelper/SMWTrackContainer.attributes.description.startDelay=The delay before the container starts moving when activated. Only applies if the container needs to be started with a touch/flag.
 
 # Flag Gate Container
 entities.EeveeHelper/FlagGateContainer.attributes.description.fitContained=Whether the container's box is resized if entities inside it move.
@@ -141,7 +149,7 @@ entities.EeveeHelper/GlobalModifier.attributes.description.
 
 
 # SMW Track
-entities.EeveeHelper/SMWTrack.placements.name.default=SMWTrack
+entities.EeveeHelper/SMWTrack.placements.name.default=SMW Track
 entities.EeveeHelper/SMWTrack.attributes.description.color=The hex color of the track.
 entities.EeveeHelper/SMWTrack.attributes.description.inactiveColor=(Optional) The hex color of the track when the flag is inactive.
 entities.EeveeHelper/SMWTrack.attributes.description.endOpenFlag=(Optional) Flag that toggles whether the end of the track is open.
@@ -154,16 +162,24 @@ entities.EeveeHelper/SMWTrack.attributes.description.hideInactive=Disables visib
 entities.EeveeHelper/SMWTrack.attributes.description.notFlag=Inverts the flag requirement for the track to be active.
 
 # SMW Platform
-entities.EeveeHelper/SMWPlatform.placements.name.default=SMWPlatform
+entities.EeveeHelper/SMWPlatform.placements.name.linear=SMW Platform
+entities.EeveeHelper/SMWPlatform.placements.name.easing=SMW Platform (Easing)
 entities.EeveeHelper/SMWPlatform.attributes.description.fallSpeed=Maximum speed at which the platform falls when off track.
 entities.EeveeHelper/SMWPlatform.attributes.description.flag=Flag that must be active for the platform to move. Empty for always active.
 entities.EeveeHelper/SMWPlatform.attributes.description.gravity=Acceleration of the platform falling when off track.
-entities.EeveeHelper/SMWPlatform.attributes.description.moveSpeed=Speed at which the platform moves along the track.
+entities.EeveeHelper/SMWPlatform.attributes.description.moveSpeed=Speed at which the platform moves along the track, if move behaviour is Linear.
 entities.EeveeHelper/SMWPlatform.attributes.description.texturePath=Path to the graphics folder containing the platform textures.
 entities.EeveeHelper/SMWPlatform.attributes.description.direction=Initial direction the platform moves along its track.
 entities.EeveeHelper/SMWPlatform.attributes.description.disableBoost=Disables horizontal boost from track movement.
 entities.EeveeHelper/SMWPlatform.attributes.description.notFlag=Inverts the flag requirement for the platform to move.
 entities.EeveeHelper/SMWPlatform.attributes.description.startOnTouch=Makes the platform only start moving when the player touches it.
+entities.EeveeHelper/SMWPlatform.attributes.description.moveBehaviour=Whether the platform moves along the track linearly or with easing.
+entities.EeveeHelper/SMWPlatform.attributes.description.easing=The easing of the platform's movement along the track, if move behaviour is Easing.
+entities.EeveeHelper/SMWPlatform.attributes.description.easeDuration=How long the platform takes to ease along the track.
+entities.EeveeHelper/SMWPlatform.attributes.description.easeTrackDirection=Whether the track's direction should affect the easing. If enabled, the platform will smoothly "bounce back" when it reaches the end of the track.
+entities.EeveeHelper/SMWPlatform.attributes.description.stopAtEnd=Whether the platform should stop moving when it reaches the end of the track.
+entities.EeveeHelper/SMWPlatform.attributes.description.moveOnce=Whether the platform can be re-activated after stopping.
+entities.EeveeHelper/SMWPlatform.attributes.description.startDelay=The delay before the platform starts moving when activated. Only applies if the platform needs to be started with a touch/flag.
 
 # Room Chest
 entities.EeveeHelper/RoomChest.placements.name.default=Room Chest (WIP)

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -116,8 +116,9 @@ entities.EeveeHelper/SMWTrackContainer.attributes.description.moveBehaviour=Whet
 entities.EeveeHelper/SMWTrackContainer.attributes.description.easing=The easing of the container's movement along the track, if move behaviour is Easing.
 entities.EeveeHelper/SMWTrackContainer.attributes.description.easeDuration=How long the container takes to ease along the track.
 entities.EeveeHelper/SMWTrackContainer.attributes.description.easeTrackDirection=Whether the track's direction should affect the easing. If enabled, the container will smoothly "bounce back" when it reaches the end of the track.
-entities.EeveeHelper/SMWTrackContainer.attributes.description.stopAtEnd=Whether the container should stop moving when it reaches the end of the track.
-entities.EeveeHelper/SMWTrackContainer.attributes.description.moveOnce=Whether the container can be re-activated after after stopping.
+entities.EeveeHelper/SMWTrackContainer.attributes.description.stopAtNode=Whether the container should stop moving when it reaches a node on the track.
+entities.EeveeHelper/SMWTrackContainer.attributes.description.stopAtEnd=Whether the container should stop moving when it reaches the end of the track. (Always enabled if Stop At Node is enabled)
+entities.EeveeHelper/SMWTrackContainer.attributes.description.moveOnce=Whether the container can be re-activated after reaching the end of the track. (Only if Stop At Node/End is enabled)
 entities.EeveeHelper/SMWTrackContainer.attributes.description.startDelay=The delay before the container starts moving when activated. Only applies if the container needs to be started with a touch/flag.
 
 # Flag Gate Container
@@ -177,8 +178,9 @@ entities.EeveeHelper/SMWPlatform.attributes.description.moveBehaviour=Whether th
 entities.EeveeHelper/SMWPlatform.attributes.description.easing=The easing of the platform's movement along the track, if move behaviour is Easing.
 entities.EeveeHelper/SMWPlatform.attributes.description.easeDuration=How long the platform takes to ease along the track.
 entities.EeveeHelper/SMWPlatform.attributes.description.easeTrackDirection=Whether the track's direction should affect the easing. If enabled, the platform will smoothly "bounce back" when it reaches the end of the track.
-entities.EeveeHelper/SMWPlatform.attributes.description.stopAtEnd=Whether the platform should stop moving when it reaches the end of the track.
-entities.EeveeHelper/SMWPlatform.attributes.description.moveOnce=Whether the platform can be re-activated after stopping.
+entities.EeveeHelper/SMWPlatform.attributes.description.stopAtNode=Whether the platform should stop moving when it reaches a node on the track.
+entities.EeveeHelper/SMWPlatform.attributes.description.stopAtEnd=Whether the platform should stop moving when it reaches the end of the track. (Always enabled if Stop At Node is enabled)
+entities.EeveeHelper/SMWPlatform.attributes.description.moveOnce=Whether the platform can be re-activated after reaching the end of the track. (Only if Stop At Node/End is enabled)
 entities.EeveeHelper/SMWPlatform.attributes.description.startDelay=The delay before the platform starts moving when activated. Only applies if the platform needs to be started with a touch/flag.
 
 # Room Chest


### PR DESCRIPTION
This update mainly adds an Easing mode for track movers, allowing them to ease back and forth like vanilla moving platforms, and a few options (maybe too many options at this point) to customize their behaviour.
This is a list of additions:

- Easing mode, and relevant options
- "Stop At End" toggle to stop the platform at the end of the track, which can be reactivated unless Move Once is enabled
- "Stop At Node" toggle to stop the platform at each node of the track (also stops at the end)
- "Start Delay" option to wait before the platform starts moving
- Fix for platforms not being able to latch onto vertical tracks while falling straight down

Backwards compatibility has only been tested on [Sky High](https://gamebanana.com/mods/150555) since I cant find any other maps that use these, however the only change I made that should be able to break any backwards compatiblity is the fix for latching onto vertical tracks (which I assume no levels would use as it clearly did not work right). If this does break some level vitellary and I are unaware of get them to yell at me