### PR TITLE
Seal Solidifier for better performance

### DIFF
--- a/Code/Entities/Modifiers/CollidableModifier.cs
+++ b/Code/Entities/Modifiers/CollidableModifier.cs
@@ -110,7 +110,7 @@ namespace Celeste.Mod.EeveeHelper.Entities.Modifiers {
             Hazardous
         }
 
-        public class Solidifier : Solid {
+        public sealed class Solidifier : Solid {
             public Entity Entity;
 
             public Solidifier(Entity entity) : base(EeveeUtils.GetPosition(entity), 1f, 1f, false) {


### PR DESCRIPTION
Seals the `CollidableModifier.Solidifier` class, which is used in the famous `Collide_Check_Entity_Entity` hook:
```cs
 if (a == null || b == null || (a is CollidableModifier.Solidifier aSolid && aSolid.Entity == b) ||
    (b is CollidableModifier.Solidifier bSolid && bSolid.Entity == a)) {
    return false;
}
```
`is` checks on sealed classes get compiled down to one int comparison, while on non-sealed classes, it requires a much slower operation.

Checked on .NET Core branch of everest, in the last gameplay room of Stellaris:
![image](https://github.com/lilybeevee/eevee-helper/assets/50085307/4874f13e-5b36-436f-88a4-7e27191585f1)
![image](https://github.com/lilybeevee/eevee-helper/assets/50085307/06b71034-a5e4-45d7-94bf-a699ae15ffd4)
