### PR TITLE
Many Room Chest fixes & tweaks

### DIFF
--- a/Ahorn/entities/roomChest.jl
+++ b/Ahorn/entities/roomChest.jl
@@ -2,10 +2,10 @@ module EeveeHelperRoomChest
 
 using ..Ahorn, Maple
 
-@mapdef Entity "EeveeHelper/RoomChest" RoomChest(x::Integer, y::Integer, room::String="")
+@mapdef Entity "EeveeHelper/RoomChest" RoomChest(x::Integer, y::Integer, room::String="", exitOnDeath::Bool=false)
 
 const placements = Ahorn.PlacementDict(
-    "Room Chest (WIP) (Eevee Helper)" => Ahorn.EntityPlacement(
+    "Room Chest (Eevee Helper)" => Ahorn.EntityPlacement(
         RoomChest
     )
 )

--- a/Ahorn/entities/roomChestExit.jl
+++ b/Ahorn/entities/roomChestExit.jl
@@ -2,10 +2,10 @@ module EeveeHelperRoomChestExit
 
 using ..Ahorn, Maple
 
-@mapdef Entity "EeveeHelper/RoomChestExit" RoomChestExit(x::Integer, y::Integer, width::Integer=8, height::Integer=8)
+@mapdef Entity "EeveeHelper/RoomChestExit" RoomChestExit(x::Integer, y::Integer, width::Integer=8, height::Integer=8, visible::Bool=false)
 
 const placements = Ahorn.PlacementDict(
-    "Room Chest Exit (WIP) (Eevee Helper)" => Ahorn.EntityPlacement(
+    "Room Chest Exit (Eevee Helper)" => Ahorn.EntityPlacement(
         RoomChestExit,
         "rectangle"
     ),

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -169,6 +169,10 @@ placements.entities.EeveeHelper/SMWPlatform.tooltips.startDelay=The delay before
 
 # Room Chest
 placements.entities.EeveeHelper/RoomChest.tooltips.room=Name of the room this chest should take you to.
+placements.entities.EeveeHelper/RoomChest.tooltips.exitOnDeath=Whether dying should take you back out of this room chest.\nChains until you reach a chest without Exit On Death enabled, or until you exit all room chests.
+
+# Room Chest Exit
+placements.entities.EeveeHelper/RoomChestExit.tooltips.visible=Whether the exit will be visible as a transparent red rectangle.
 
 # Core Zone
 placements.entities.EeveeHelper/CoreZone.tooltips.zoneId=(Optional) Makes this Core Zone's mode affected by matching Core Zone Toggles instead of the level's core mode.

--- a/Code/Compat/SpeedrunToolCompat.cs
+++ b/Code/Compat/SpeedrunToolCompat.cs
@@ -1,0 +1,19 @@
+﻿using Celeste.Mod.EeveeHelper.Entities;
+using MonoMod.ModInterop;
+using System;
+
+namespace Celeste.Mod.EeveeHelper.Compat {
+    public class SpeedrunToolCompat {
+
+        public static void Initialize() {
+            typeof(SaveLoadImports).ModInterop();
+
+            SaveLoadImports.RegisterStaticTypes(typeof(RoomChest), new string[] { "LastEntities", "LastChests", "LastRooms", "LastSpawnPoints", "OriginalSession", "OriginalModSessions" });
+        }
+
+        [ModImportName("SpeedrunTool.SaveLoad")]
+        private static class SaveLoadImports {
+            public static Func<Type, string[], object> RegisterStaticTypes;
+        }
+    }
+}

--- a/Code/EeveeHelperModule.cs
+++ b/Code/EeveeHelperModule.cs
@@ -25,6 +25,7 @@ namespace Celeste.Mod.EeveeHelper {
 
         public static bool AdventureHelperLoaded { get; set; }
         public static bool StyleMaskHelperLoaded { get; set; }
+        public static bool SpeedrunToolLoaded { get; set; }
 
         public override void Load() {
             MiscHooks.Load();
@@ -62,6 +63,8 @@ namespace Celeste.Mod.EeveeHelper {
         }
 
         public override void Initialize() {
+            RoomChest.Initialize();
+
             AdventureHelperLoaded = Everest.Loader.DependencyLoaded(new EverestModuleMetadata {
                 Name = "AdventureHelper",
                 VersionString = "1.5.1"
@@ -70,10 +73,16 @@ namespace Celeste.Mod.EeveeHelper {
                 Name = "StyleMaskHelper",
                 VersionString = "1.2.0"
             });
+            SpeedrunToolLoaded = Everest.Loader.DependencyLoaded(new EverestModuleMetadata {
+                Name = "SpeedrunTool",
+                VersionString = "3.21.0"
+            });
 
-            if (AdventureHelperLoaded) {
+            if (AdventureHelperLoaded)
                 AdventureHelperCompat.Initialize();
-            }
+
+            if (SpeedrunToolLoaded)
+                SpeedrunToolCompat.Initialize();
         }
 
         private Backdrop OnLoadBackdrop(MapData map, BinaryPacker.Element child, BinaryPacker.Element above) {

--- a/Code/EeveeUtils.cs
+++ b/Code/EeveeUtils.cs
@@ -44,5 +44,17 @@ namespace Celeste.Mod.EeveeHelper {
                 newData.Values = new Dictionary<string, object>(data.Values);
             return newData;
         }
+
+        public static T GetValueOfType<T>(Dictionary<Type, T> dict, Type type) {
+            var success = dict.TryGetValue(type, out T value);
+
+            if (success)
+                return value;
+
+            if (type.BaseType == null)
+                return default(T);
+
+            return GetValueOfType(dict, type.BaseType);
+        }
     }
 }

--- a/Code/Entities/RoomChest.cs
+++ b/Code/Entities/RoomChest.cs
@@ -6,18 +6,27 @@ using MonoMod.Cil;
 using MonoMod.Utils;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
+using System.Xml.Serialization;
 
 namespace Celeste.Mod.EeveeHelper.Entities {
     [CustomEntity("EeveeHelper/RoomChest")]
     public class RoomChest : Actor {
-        public static Stack<List<Entity>> LastEntities = new Stack<List<Entity>>();
-        public static Stack<RoomChest> LastChests = new Stack<RoomChest>();
-        public static Stack<string> LastRooms = new Stack<string>();
+        public static Stack<List<Entity>> LastEntities = new();
+        public static Stack<RoomChest> LastChests = new();
+        public static Stack<string> LastRooms = new();
+        public static Stack<Vector2?> LastSpawnPoints = new();
+
+        public static byte[] OriginalSession;
+        public static Dictionary<string, byte[]> OriginalModSessions = new();
+
+        public static Dictionary<Type, Func<Holdable, List<Entity>>> HoldableEntityGetters = new();
 
         public static bool NoEntityCallbacks;
 
         public string Room;
+        public bool ExitOnDeath;
 
         public Vector2 Speed;
         public Holdable Hold;
@@ -29,12 +38,13 @@ namespace Celeste.Mod.EeveeHelper.Entities {
         private Vector2 prevLiftSpeed;
         private float noGravityTimer;
         private bool playerWasAbove;
-        private Player playerInside;
+        private bool playerInside;
         private float squishTimer;
         private bool closed;
 
         public RoomChest(EntityData data, Vector2 offset) : base(data.Position + offset) {
             Room = data.Attr("room");
+            ExitOnDeath = data.Bool("exitOnDeath", false);
 
             Depth = 5;
             Collider = new Hitbox(16f, 8f, -8f, -8f);
@@ -76,26 +86,26 @@ namespace Celeste.Mod.EeveeHelper.Entities {
             }
 
             var player = level.Tracker.GetEntity<Player>();
-            var wasInside = playerInside != null;
+            var wasInside = playerInside;
             var wasClosed = closed;
             if (player != null) {
                 var inside = !Hold.IsHeld && player.Left >= Left - 2f && player.Right <= Right + 2f && player.Bottom >= Top && player.Bottom <= Bottom;
-                if (playerInside == null && inside && playerWasAbove) {
+                if (!playerInside && inside && playerWasAbove) {
                     player.Left = Math.Max(player.Left, Left);
                     player.Right = Math.Min(player.Right, Right);
-                    playerInside = player;
+                    playerInside = true;
                 } else if (!inside) {
-                    playerInside = null;
+                    playerInside = false;
                 }
                 playerWasAbove = player.Bottom <= Top;
             } else {
                 playerWasAbove = false;
             }
 
-            if (playerInside != null) {
+            if (playerInside) {
                 Depth = -5;
                 ChestLid.Collidable = true;
-                closed = playerInside.Ducking || (playerInside.Holding != null && !Exiting);
+                closed = player.Ducking || (player.Holding != null && !Exiting);
             } else {
                 Depth = 5;
                 ChestLid.Collidable = false;
@@ -109,11 +119,15 @@ namespace Celeste.Mod.EeveeHelper.Entities {
                 closedImage.Visible = true;
                 closedImage.Scale = new Vector2(1.2f, 0.8f);
                 player.Visible = false;
-                if (player.Holding != null)
+                if (player.Holding != null) {
                     player.Holding.Entity.Visible = false;
+                    foreach (var entity in GetHeldEntityAttachments(player.Holding)) {
+                        entity.Visible = false;
+                    }
+                }
                 squishTimer = 0.05f;
                 if (!string.IsNullOrEmpty(Room)) {
-                    if (playerInside.Ducking)
+                    if (player.Ducking)
                         ChestLid.TopSolid = true;
                     ChangeRoom();
                 }
@@ -124,8 +138,12 @@ namespace Celeste.Mod.EeveeHelper.Entities {
                 bodyImage.Scale = new Vector2(0.8f, 1.2f);
                 ChestLid.Scale = new Vector2(0.8f, 1.2f);
                 player.Visible = true;
-                if (player.Holding != null)
+                if (player.Holding != null) {
                     player.Holding.Entity.Visible = true;
+                    foreach (var entity in GetHeldEntityAttachments(player.Holding)) {
+                        entity.Visible = true;
+                    }
+                }
                 squishTimer = 0.05f;
             }
 
@@ -187,18 +205,31 @@ namespace Celeste.Mod.EeveeHelper.Entities {
             }
             Hold.CheckAgainstColliders();
 
-            ChestLid.MoveTo(Position);
+            if (ChestLid.Scene != null)
+                ChestLid.MoveTo(Position);
         }
 
         private void ChangeRoom() {
             var level = SceneAs<Level>();
+            var player = level.Tracker.GetEntity<Player>();
+
+            player.StateMachine.State = Player.StDummy;
+
             Add(Alarm.Create(Alarm.AlarmMode.Oneshot, () => {
                 level.DoScreenWipe(false, () => {
-                    var player = level.Tracker.GetEntity<Player>();
                     var dashes = player.Dashes;
+
+                    if (LastRooms.Count == 0) {
+                        // Save the original session to revert to when the player saves and quits
+                        OriginalSession = UserIO.Serialize(level.Session);
+
+                        foreach (var module in Everest.Modules)
+                            OriginalModSessions.Add(module.Metadata.Name, module.SerializeSession(SaveData.Instance.FileSlot));
+                    }
 
                     LastChests.Push(this);
                     LastRooms.Push(level.Session.Level);
+                    LastSpawnPoints.Push(level.Session.RespawnPoint);
 
                     player.CleanUpTriggers();
 
@@ -206,6 +237,10 @@ namespace Celeste.Mod.EeveeHelper.Entities {
                     if (player.Holding != null) {
                         held = player.Holding;
                         level.Remove(player.Holding.Entity);
+
+                        foreach (var entity in GetHeldEntityAttachments(held))
+                            level.Remove(entity);
+
                         player.Holding = null;
                     }
 
@@ -230,12 +265,21 @@ namespace Celeste.Mod.EeveeHelper.Entities {
                     level.LoadLevel(Player.IntroTypes.Transition);
 
                     level.Add(player);
+                    level.Entities.UpdateLists();
+
                     if (held != null) {
                         level.Add(held.Entity);
-                        player.Holding = held;
                         held.Entity.Visible = true;
+
+                        foreach (var entity in GetHeldEntityAttachments(held)) {
+                            level.Add(entity);
+                            entity.Visible = true;
+                        }
+
+                        player.Holding = held;
                     }
-                    level.Entities.UpdateLists();
+
+                    player.StateMachine.State = Player.StNormal;
 
                     player.Visible = true;
                     player.Position = level.DefaultSpawnPoint;
@@ -276,7 +320,9 @@ namespace Celeste.Mod.EeveeHelper.Entities {
 
         private void OnCarry(Vector2 target) {
             Position = target;
-            ChestLid.MoveTo(ExactPosition);
+
+            if (ChestLid.Scene != null)
+                ChestLid.MoveTo(ExactPosition);
         }
 
         private void OnPickup() {
@@ -298,10 +344,12 @@ namespace Celeste.Mod.EeveeHelper.Entities {
         }
 
         public static void DeactivateEntities(Level level) {
+            var player = level.Tracker.GetEntity<Player>();
+
             var deactivated = new List<Entity>();
             foreach (var entity in level.GetEntitiesExcludingTagMask(Tags.Global)) {
                 level.Remove(entity);
-                if (IsEntitySaved(entity))
+                if (IsEntitySaved(entity) && entity != player)
                     deactivated.Add(entity);
             }
             LastEntities.Push(deactivated);
@@ -333,28 +381,115 @@ namespace Celeste.Mod.EeveeHelper.Entities {
 
         public static bool IsEntitySaved(Entity entity) => !(entity is Trigger);
 
+        public static List<Entity> GetHeldEntityAttachments(Holdable holdable) {
+            var getter = EeveeUtils.GetValueOfType(HoldableEntityGetters, holdable.Entity.GetType());
+
+            if (getter == null)
+                return new List<Entity>();
+
+            return getter(holdable);
+        }
+
 
         private static MethodInfo m_Scene_SetActualDepth = typeof(Scene).GetMethod("SetActualDepth", BindingFlags.NonPublic | BindingFlags.Instance);
         private static MethodInfo m_Tracker_ComponentAdded = typeof(Tracker).GetMethod("ComponentAdded", BindingFlags.NonPublic | BindingFlags.Instance);
         private static MethodInfo m_Tracker_ComponentRemoved = typeof(Tracker).GetMethod("ComponentRemoved", BindingFlags.NonPublic | BindingFlags.Instance);
 
+        public static void Initialize() {
+            HoldableEntityGetters.Add(typeof(RoomChest), (holdable) => {
+                var chest = holdable.Entity as RoomChest;
+
+                return new List<Entity>() {
+                    chest.ChestLid
+                };
+            });
+
+            HoldableEntityGetters.Add(typeof(HoldableTiles), (holdable) => {
+                var tiles = holdable.Entity as HoldableTiles;
+
+                return new List<Entity>() {
+                    tiles.Solid
+                };
+            });
+
+            HoldableEntityGetters.Add(typeof(HoldableContainer), (holdable) => {
+                var entity = holdable.Entity as HoldableContainer;
+
+                return entity.Container.GetEntities();
+            });
+        }
+
         public static void Load() {
             On.Celeste.Level.LoadLevel += Level_LoadLevel;
+            On.Celeste.Level.End += Level_End;
+            On.Celeste.SaveData.BeforeSave += SaveData_BeforeSave;
+            On.Celeste.Player.Die += Player_Die;
             IL.Monocle.EntityList.UpdateLists += EntityList_UpdateLists;
         }
 
         public static void Unload() {
             On.Celeste.Level.LoadLevel -= Level_LoadLevel;
+            On.Celeste.Level.End -= Level_End;
+            On.Celeste.SaveData.BeforeSave -= SaveData_BeforeSave;
+            On.Celeste.Player.Die -= Player_Die;
             IL.Monocle.EntityList.UpdateLists -= EntityList_UpdateLists;
         }
 
         private static void Level_LoadLevel(On.Celeste.Level.orig_LoadLevel orig, Level self, Player.IntroTypes playerIntro, bool isFromLoader) {
             if (isFromLoader) {
-                LastEntities.Clear();
-                LastChests.Clear();
-                LastRooms.Clear();
+                OriginalSession = null;
+                OriginalModSessions.Clear();
             }
+
             orig(self, playerIntro, isFromLoader);
+        }
+
+        private static void Level_End(On.Celeste.Level.orig_End orig, Level self) {
+            orig(self);
+
+            LastEntities.Clear();
+            LastChests.Clear();
+            LastRooms.Clear();
+            LastSpawnPoints.Clear();
+        }
+
+        private static void SaveData_BeforeSave(On.Celeste.SaveData.orig_BeforeSave orig, SaveData self) {
+            if (OriginalSession != null) {
+                // If currently inside a room chest, load session from before entering the first chest
+                using (var stream = new MemoryStream(OriginalSession)) {
+                    self.CurrentSession_Safe = (Session)(new XmlSerializer(typeof(Session)).Deserialize(stream));
+                }
+                foreach (var module in Everest.Modules) {
+                    if (OriginalModSessions.TryGetValue(module.Metadata.Name, out var data)) {
+                        module.DeserializeSession(self.FileSlot, data);
+                    }
+                }
+            }
+
+            orig(self);
+        }
+
+        private static PlayerDeadBody Player_Die(On.Celeste.Player.orig_Die orig, Player self, Vector2 direction, bool evenIfInvincible, bool registerDeathInStats) {
+            var level = self.SceneAs<Level>();
+
+            var body = orig(self, direction, evenIfInvincible, registerDeathInStats);
+
+            if (body != null) {
+                while (LastChests.Count > 0 && LastChests.Peek().ExitOnDeath) {
+                    level.Session.Level = LastRooms.Pop();
+                    level.Session.RespawnPoint = LastSpawnPoints.Pop();
+
+                    LastChests.Pop();
+                    LastEntities.Pop();
+
+                    if (LastChests.Count == 0) {
+                        OriginalSession = null;
+                        OriginalModSessions.Clear();
+                    }
+                }
+            }
+
+            return body;
         }
 
         private static void EntityList_UpdateLists(MonoMod.Cil.ILContext il) {

--- a/Code/Entities/RoomChest.cs
+++ b/Code/Entities/RoomChest.cs
@@ -72,6 +72,13 @@ namespace Celeste.Mod.EeveeHelper.Entities {
             scene.Add(ChestLid = new ChestExtension(this, Position));
         }
 
+        public override void Removed(Scene scene) {
+            base.Removed(scene);
+
+            if (ChestLid != null && ChestLid.Scene == scene)
+                scene.Remove(ChestLid);
+        }
+
         public override void Update() {
             base.Update();
 

--- a/Code/Entities/RoomChestExit.cs
+++ b/Code/Entities/RoomChestExit.cs
@@ -10,13 +10,20 @@ using System.Threading.Tasks;
 namespace Celeste.Mod.EeveeHelper.Entities {
     [CustomEntity("EeveeHelper/RoomChestExit")]
     public class RoomChestExit : Entity {
+        public bool DrawRect;
+
         public RoomChestExit(EntityData data, Vector2 offset) : base(data.Position + offset) {
+            DrawRect = data.Bool("visible", true);
+
             Depth = 1000;
             Collider = new Hitbox(data.Width, data.Height);
 
             Add(new TalkComponent(new Rectangle(0, 0, data.Width, data.Height), new Vector2(data.Width/2, data.Height/4), (player) => {
                 if (RoomChest.LastRooms.Count == 0)
                     return;
+
+                player.StateMachine.State = Player.StDummy;
+                player.DummyGravity = false;
 
                 var level = SceneAs<Level>();
                 Add(Alarm.Create(Alarm.AlarmMode.Oneshot, () => {
@@ -30,6 +37,10 @@ namespace Celeste.Mod.EeveeHelper.Entities {
                             if (player.Holding != null) {
                                 held = player.Holding;
                                 level.Remove(player.Holding.Entity);
+
+                                foreach (var entity in RoomChest.GetHeldEntityAttachments(held))
+                                    level.Remove(entity);
+
                                 player.Holding = null;
                             }
 
@@ -51,20 +62,22 @@ namespace Celeste.Mod.EeveeHelper.Entities {
                             level.Session.RespawnPoint = level.DefaultSpawnPoint;
                             level.Add(player);
                             var exclude = new List<Entity>() { player };
-                            if (held != null) {
+                            /*if (held != null) {
                                 level.Add(held.Entity);
                                 exclude.Add(held.Entity);
                                 player.Holding = held;
-                            }
+                            }*/
                             level.LoadLevel(Player.IntroTypes.Transition);
                             RoomChest.ActivateEntities(level, exclude);
 
-                            /*level.Add(player);
                             if (held != null) {
-                                level.Add(held.Entity);
+                                level.Add(held.Entity)
+;
+                                foreach (var entity in RoomChest.GetHeldEntityAttachments(held))
+                                    level.Add(entity);
+
                                 player.Holding = held;
                             }
-                            level.Entities.UpdateLists();*/
 
                             var lastChest = RoomChest.LastChests.Pop();
                             player.Position = lastChest.BottomCenter - Vector2.UnitY * 2f;
@@ -82,7 +95,10 @@ namespace Celeste.Mod.EeveeHelper.Entities {
                                     follower.Entity.Position = player.Position;
                                 }
                             }
+
                             RoomChest.UpdateListsNoCallbacks(level);
+
+                            player.StateMachine.State = Player.StNormal;
 
                             if (player.Holding == null) {
                                 player.Ducking = true;
@@ -105,6 +121,14 @@ namespace Celeste.Mod.EeveeHelper.Entities {
                             camPosition.Y = MathHelper.Clamp(camPosition.Y, level.Bounds.Top, level.Bounds.Bottom - 180);
                             level.Camera.Position = camPosition;
 
+                            RoomChest.LastSpawnPoints.Pop();
+
+                            if (RoomChest.LastRooms.Count == 0) {
+                                // Exited all room chests, no need to revert session after saving
+                                RoomChest.OriginalSession = null;
+                                RoomChest.OriginalModSessions.Clear();
+                            }
+
                             level.DoScreenWipe(true);
                         };
                     });
@@ -122,7 +146,8 @@ namespace Celeste.Mod.EeveeHelper.Entities {
 
         public override void Render() {
             base.Render();
-            Draw.Rect(Collider, Color.LightPink * 0.2f);
+            if (DrawRect)
+                Draw.Rect(Collider, Color.LightPink * 0.2f);
         }
     }
 }

--- a/Loenn/entities/roomChest.lua
+++ b/Loenn/entities/roomChest.lua
@@ -7,6 +7,7 @@ local roomChest = {
         name = "default",
         data = {
             room = "",
+            exitOnDeath = false,
         }
     },
     sprite = function (room, entity)

--- a/Loenn/entities/roomChestExit.lua
+++ b/Loenn/entities/roomChestExit.lua
@@ -9,6 +9,7 @@ local roomChestExit = {
         data = {
             width = 8,
             height = 8,
+            visible = true,
         }
     }
 }

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -188,11 +188,13 @@ entities.EeveeHelper/SMWPlatform.attributes.description.moveOnce=Whether the pla
 entities.EeveeHelper/SMWPlatform.attributes.description.startDelay=The delay before the platform starts moving when activated. Only applies if the platform needs to be started with a touch/flag.
 
 # Room Chest
-entities.EeveeHelper/RoomChest.placements.name.default=Room Chest (WIP)
+entities.EeveeHelper/RoomChest.placements.name.default=Room Chest
 entities.EeveeHelper/RoomChest.attributes.description.room=Name of the room this chest should take you to.
+entities.EeveeHelper/RoomChest.attributes.description.exitOnDeath=Whether dying should take you back out of this room chest.\nChains until you reach a chest without Exit On Death enabled, or until you exit all room chests.
 
 # Room Chest Exit
-entities.EeveeHelper/RoomChestExit.placements.name.default=Room Chest Exit (WIP)
+entities.EeveeHelper/RoomChestExit.placements.name.default=Room Chest Exit
+entities.EeveeHelper/RoomChestExit.attributes.description.visible=Whether the exit will be visible as a transparent red rectangle.
 
 # Patient Booster
 entities.EeveeHelper/PatientBooster.placements.name.default=Patient Booster

--- a/everest.yaml
+++ b/everest.yaml
@@ -9,3 +9,5 @@
       Version: 1.5.1
     - Name: StyleMaskHelper
       Version: 1.2.0
+    - Name: SpeedrunTool
+      Version: 3.21.0


### PR DESCRIPTION
- Added Exit On Death option to Room Chests
- Added option to disable Room Chest Exit rectangle (i couldnt think of a sprite so you can just use decals)
- "Save and Quit" in a room chest now reloads the session from outside any room chests
- Speedrun Tool savestates are now compatible with room chests
- Fixed entering and exiting room chests when holding room chests, holdable tiles, and holdable containers
- Fixed being able to exit room chests multiple times and crashing
- Fixed room chest lid not being removed sometimes

Fixes #10 