### PR TITLE
More Flag Toggle Modifier options, Depth Modifier improvement

### DIFF
--- a/Code/Entities/Modifiers/DepthModifier.cs
+++ b/Code/Entities/Modifiers/DepthModifier.cs
@@ -26,6 +26,13 @@ namespace Celeste.Mod.EeveeHelper.Entities.Modifiers {
             });
         }
 
+        public override void Update() {
+            base.Update();
+
+            foreach (var handler in Container.Contained)
+                ModifyDepth(handler);
+        }
+
         private void ModifyDepth(IEntityHandler handler) {
             var entity = handler.Entity;
 

--- a/Code/Entities/Modifiers/FlagToggleModifier.cs
+++ b/Code/Entities/Modifiers/FlagToggleModifier.cs
@@ -86,7 +86,7 @@ namespace Celeste.Mod.EeveeHelper.Entities.Modifiers {
             if (!entityStates.ContainsKey(handler)) {
                 var state = HandlerUtils.GetAs<IToggleable, object>(handler,
                     t => rememberInitialState ? t.SaveState() : t.GetDefaultState(),
-                    e => rememberInitialState ? new EntityState(e) : new EntityState());
+                    e => rememberInitialState ? new EntityState(e) : new EntityState(true));
 
                 if (state != null)
                     entityStates.Add(handler, state);
@@ -120,12 +120,12 @@ namespace Celeste.Mod.EeveeHelper.Entities.Modifiers {
 
             public bool TalkComponentEnabled;
 
-            public EntityState() {
-                Active = true;
-                Visible = true;
-                Collidable = true;
+            public EntityState(bool value) {
+                Active = value;
+                Visible = value;
+                Collidable = value;
 
-                TalkComponentEnabled = true;
+                TalkComponentEnabled = value;
             }
 
             public EntityState(Entity entity) {

--- a/Code/Handlers/IToggleable.cs
+++ b/Code/Handlers/IToggleable.cs
@@ -6,6 +6,8 @@ using System.Threading.Tasks;
 
 namespace Celeste.Mod.EeveeHelper.Handlers {
     public interface IToggleable {
+        object GetDefaultState();
+
         object SaveState();
 
         void ReadState(object state, bool toggleActive, bool toggleVisible, bool toggleCollidable);

--- a/Loenn/entities/entityContainers.lua
+++ b/Loenn/entities/entityContainers.lua
@@ -267,6 +267,8 @@ local flagToggleModifier = {
             toggleActive = true,
             toggleVisible = true,
             toggleCollidable = true,
+            rememberInitialState = true,
+            delayedToggle = false,
         }
     }
 }

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -158,6 +158,8 @@ entities.EeveeHelper/FlagToggleModifier.attributes.description.notFlag=Inverts t
 entities.EeveeHelper/FlagToggleModifier.attributes.description.toggleActive=Controls whether toggling will affect if entities update (move/act on their own).
 entities.EeveeHelper/FlagToggleModifier.attributes.description.toggleVisible=Controls whether toggling will affect if entities are visible.
 entities.EeveeHelper/FlagToggleModifier.attributes.description.toggleCollidable=Controls whether toggling will affect if entities are collidable.
+entities.EeveeHelper/FlagToggleModifier.attributes.description.rememberInitialState=Whether the state of the entities (active, visible, collidable) when they were first disabled should be remembered when the entities are re-enabled.
+entities.EeveeHelper/FlagToggleModifier.attributes.description.delayedToggle=(Legacy behaviour) If enabled, entities will not toggle off the moment they enter the container, and will instead wait for the next update tick.
 
 # Collidable Modifier
 entities.EeveeHelper/CollidableModifier.attributes.description.collisionMode=The type of collision the modified entities should be given.


### PR DESCRIPTION
- Allow disabling Flag Toggle Modifier's behaviour of remembering the initial entity states
- Fix Flag Toggle Modifier not toggling entities immediately (with legacy option)
- Depth Modifier now sets entity depth every tick