### PR TITLE
Fix Room Chest setting player position to a non-integer

### DIFF
--- a/Code/Entities/RoomChestExit.cs
+++ b/Code/Entities/RoomChestExit.cs
@@ -93,7 +93,7 @@ public class RoomChestExit : Entity
 						}
 
 						var lastChest = RoomChest.LastChests.Pop();
-						player.Position = lastChest.BottomCenter - Vector2.UnitY * 2f;
+						player.Position = (lastChest.BottomCenter - Vector2.UnitY * 2f).Floor();
 						player.Dashes = dashes;
 
 						player.Leader.Followers = lastFollowers;


### PR DESCRIPTION
Caused the player hitbox to sometimes become incorrectly larger