### PR TITLE
Add SpeedSetter to holdables

### DIFF
--- a/Code/Entities/Containers/HoldableContainer.cs
+++ b/Code/Entities/Containers/HoldableContainer.cs
@@ -83,6 +83,7 @@ public class HoldableContainer : Actor, IContainer
 				OnRelease = OnRelease,
 				OnHitSpring = HitSpring,
 				SpeedGetter = () => Speed,
+				SpeedSetter = (speed) => Speed = speed,
 				OnCarry = OnCarry
 			});
 

--- a/Code/Entities/HoldableTiles.cs
+++ b/Code/Entities/HoldableTiles.cs
@@ -48,6 +48,7 @@ public class HoldableTiles : Actor
 				OnRelease = OnRelease,
 				OnHitSpring = HitSpring,
 				SpeedGetter = () => Speed,
+				SpeedSetter = (speed) => Speed = speed,
 				OnCarry = OnCarry
 			});
 		}

--- a/Code/Entities/RoomChest.cs
+++ b/Code/Entities/RoomChest.cs
@@ -64,6 +64,7 @@ public class RoomChest : Actor
 			OnPickup = OnPickup,
 			OnRelease = OnRelease,
 			SpeedGetter = () => Speed,
+			SpeedSetter = (speed) => Speed = speed,
 			SlowRun = false,
 			SlowFall = false
 		});


### PR DESCRIPTION
This allows holdables to be affected by entities that use SpeedSetter (e.g. Frost Helper custom springs)