### PR TITLE
roomchest crash from duplicated modsession instantiation

### DIFF
--- a/Code/Entities/RoomChest.cs
+++ b/Code/Entities/RoomChest.cs
@@ -289,7 +289,7 @@ public class RoomChest : Actor
 
 					foreach (var module in Everest.Modules)
 					{
-						OriginalModSessions.Add(module.Metadata.Name, module.SerializeSession(SaveData.Instance.FileSlot));
+						OriginalModSessions[module.Metadata.Name] = module.SerializeSession(SaveData.Instance.FileSlot);
 					}
 				}
 


### PR DESCRIPTION
Room Chest duplicates modsessions in some instances. This causes an ArgumentException in ModSessions.Add(key, value)
