### PR TITLE
Add Shake Strength to Flag Gate Container

### DIFF
--- a/Code/Entities/Containers/FlagGateContainer.cs
+++ b/Code/Entities/Containers/FlagGateContainer.cs
@@ -60,6 +60,7 @@ public class FlagGateContainer : Entity, IContainer
 
 	private bool shaking;
 	private float shakeTimer;
+	private float shakeStrength;
 	private Vector2 shakeAmount;
 	private Random shakeRand;
 
@@ -84,6 +85,7 @@ public class FlagGateContainer : Entity, IContainer
 		//resetFlags = data.Bool("resetFlags", true);
 		canReturn = data.Bool("canReturn", true);
 		shakeTime = data.Float("shakeTime", 0.5f);
+		shakeStrength = data.Float("shakeStrength", 1f);
 		moveTime = data.Float("moveTime", 2f);
 		//progression = data.Bool("progression");
 		easer = EeveeHelperModule.EaseTypes[data.Attr("easing", "CubeOut")];
@@ -169,7 +171,7 @@ public class FlagGateContainer : Entity, IContainer
 		{
 			if (Scene.OnInterval(0.04f))
 			{
-				shakeAmount = shakeRand.ShakeVector();
+				shakeAmount = shakeStrength * shakeRand.ShakeVector();
 			}
 			if (shakeTimer > 0f)
 			{

--- a/Loenn/entities/entityContainers.lua
+++ b/Loenn/entities/entityContainers.lua
@@ -233,6 +233,7 @@ local flagGateContainer = {
                 ignoreContainerBounds = false,
                 moveFlag = "",
                 shakeTime = 0.5,
+		shakeStrength = 1.0,
                 moveTime = 2.0,
                 easing = "CubeOut",
                 icon = "objects/switchgate/icon",

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -148,6 +148,7 @@ entities.EeveeHelper/FlagGateContainer.attributes.description.inactiveColor=The 
 entities.EeveeHelper/FlagGateContainer.attributes.description.moveFlag=The flag that activates this gate. Leave empty to function like a normal switch gate.
 entities.EeveeHelper/FlagGateContainer.attributes.description.moveTime=How long, in seconds, the container takes to move to the other node.
 entities.EeveeHelper/FlagGateContainer.attributes.description.shakeTime=How long the container shakes before moving. If set higher than 0, the container will also briefly shake when stopping.
+entities.EeveeHelper/FlagGateContainer.attributes.description.shakeStrength=How much the container moves around while shaking. 1 will give vanilla switch gate strength, 0 will make it not shake at all.
 entities.EeveeHelper/FlagGateContainer.attributes.description.easing=The easing of the container's movement between nodes.
 entities.EeveeHelper/FlagGateContainer.attributes.description.icon=The switch gate icon overlayed on the container. Can be dragged around to change position. (Icons are detected from "objects/MaxHelpingHand/flagSwitchGate/" and "objects/EeveeHelper/flagGateIcons/")
 entities.EeveeHelper/FlagGateContainer.attributes.description.canReturn=Whether the container will return to its original position if the flag is deactivated.


### PR DESCRIPTION
Adds a configurable float "shake strength" option used to modify how much contained entities shake. Has a default value of 1 for compat. Video of entities with 5.0 strength, 1.0, and 0.0 is attached

https://github.com/user-attachments/assets/bec9f5c6-cee2-4b31-be62-fcc4f7934c96

