### PR TITLE
Fix some issues with the input toggle block input listener

### DIFF
--- a/Code/Components/FreezeUpdateHook.cs
+++ b/Code/Components/FreezeUpdateHook.cs
@@ -1,0 +1,42 @@
+﻿using Monocle;
+using MonoMod.Cil;
+using System;
+using System.Linq;
+
+namespace Celeste.Mod.EeveeHelper.Components;
+
+// based on https://github.com/CommunalHelper/CommunalHelper/blob/dev/src/Entities/Misc/AbstractInputController.cs
+
+[Tracked]
+public class FreezeUpdateHook(Action onFreezeUpdate) : Component(true, false)
+{
+	public Action OnFreezeUpdate = onFreezeUpdate;
+
+    internal static void Load()
+    {
+        IL.Monocle.Engine.Update += Engine_Update;
+    }
+
+    internal static void Unload()
+    {
+        IL.Monocle.Engine.Update -= Engine_Update;
+    }
+	
+	private static void Engine_Update(ILContext il)
+	{
+		var cursor = new ILCursor(il);
+
+		if (cursor.TryGotoNext(instr => instr.MatchLdsfld<Engine>("FreezeTimer"),
+			instr => instr.MatchCall<Engine>("get_RawDeltaTime")))
+		{
+			cursor.EmitDelegate(UpdateFreezeUpdateHooks);
+		}
+	}
+
+    private static void UpdateFreezeUpdateHooks()
+    {
+        foreach (FreezeUpdateHook freezeUpdateHook in Engine.Scene.Tracker.GetComponents<FreezeUpdateHook>().Cast<FreezeUpdateHook>())
+			if (freezeUpdateHook.Active)
+            	freezeUpdateHook.OnFreezeUpdate();
+    }
+}

--- a/Code/EeveeHelper.csproj
+++ b/Code/EeveeHelper.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <AssemblyName>EeveeHelper</AssemblyName>
         <RootNamespace>Celeste.Mod.EeveeHelper</RootNamespace>
         <LangVersion>latest</LangVersion>

--- a/Code/EeveeHelperModule.cs
+++ b/Code/EeveeHelperModule.cs
@@ -1,4 +1,5 @@
 ﻿using Celeste.Mod.EeveeHelper.Compat;
+using Celeste.Mod.EeveeHelper.Components;
 using Celeste.Mod.EeveeHelper.Effects;
 using Celeste.Mod.EeveeHelper.Entities;
 using Celeste.Mod.EeveeHelper.Handlers;
@@ -36,6 +37,7 @@ public class EeveeHelperModule : EverestModule
 		HoldableTiles.Load();
 		PatientBooster.Load();
 		CoreZone.Load();
+		FreezeUpdateHook.Load();
 
 		Everest.Events.Level.OnLoadBackdrop += this.OnLoadBackdrop;
 
@@ -64,6 +66,7 @@ public class EeveeHelperModule : EverestModule
 		HoldableTiles.Unload();
 		PatientBooster.Unload();
 		CoreZone.Unload();
+		FreezeUpdateHook.Unload();
 	}
 
 	public override void Initialize()
@@ -103,6 +106,12 @@ public class EeveeHelperModule : EverestModule
 		{
 			BetterRefillGemsCompat.Initialize(betterRefillGemsModule);
 		}
+	}
+
+	public override void OnInputInitialize()
+	{
+		base.OnInputInitialize();
+		Settings.ActivateCustomInputBlock.BufferTime = 0f;
 	}
 
 	private Backdrop OnLoadBackdrop(MapData map, BinaryPacker.Element child, BinaryPacker.Element above)

--- a/Code/Entities/InputToggleBlock.cs
+++ b/Code/Entities/InputToggleBlock.cs
@@ -4,6 +4,7 @@ using Monocle;
 using System;
 using System.Collections;
 using System.Linq;
+using Celeste.Mod.EeveeHelper.Components;
 
 namespace Celeste.Mod.EeveeHelper.Entities;
 
@@ -18,15 +19,16 @@ public class InputToggleBlock : Solid
 		Custom
 	}
 
-	private string texture;
-	private Types type;
-	private float time;
-	private bool cancellable;
-	private string tutorialFlag;
+	private readonly string texture;
+	private readonly Types type;
+	private readonly float time;
+	private readonly bool cancellable;
+	private readonly string tutorialFlag;
 
 	private InputListener listener;
 	private PathRenderer path;
 	private BirdTutorialGui gui;
+
 	private Vector2 start;
 	private Vector2 end;
 	private float lerp;
@@ -51,14 +53,14 @@ public class InputToggleBlock : Solid
 	{
 		base.Added(scene);
 
-		scene.Add(listener = new InputListener(type, Depth + 1));
+		scene.Add(listener = new InputListener(type));
 
 		var color = Color.White;
 		switch (type)
 		{
-			case Types.Grab: color = new Color(1f, 0f, 1f); break;
-			case Types.Jump: color = new Color(1f, 1f, 0f); break;
-			case Types.Dash: color = new Color(0f, 1f, 1f); break;
+			case Types.Grab:   color = new Color(1f, 0f, 1f); break;
+			case Types.Jump:   color = new Color(1f, 1f, 0f); break;
+			case Types.Dash:   color = new Color(0f, 1f, 1f); break;
 			case Types.Custom: color = new Color(0f, 0f, 1f); break;
 		}
 
@@ -178,9 +180,9 @@ public class InputToggleBlock : Solid
 
 	private class PathRenderer : Entity
 	{
-		private Vector2 endpoint;
-		private MTexture texture;
-		private Color color;
+		private readonly Vector2 endpoint;
+		private readonly MTexture texture;
+		private readonly Color color;
 
 		public PathRenderer(Vector2 start, Vector2 end, string texturePath, string textureType, Color pathColor) : base(start)
 		{
@@ -202,43 +204,48 @@ public class InputToggleBlock : Solid
 
 	private class InputListener : Entity
 	{
-		private Types inputType;
+		private readonly Types inputType;
+
 		private int presses = 0;
 		private bool wasPressed;
 
-		public InputListener(Types type, int depth)
+		public InputListener(Types type)
 		{
 			inputType = type;
 
-			Depth = depth;
+			Depth = int.MaxValue; // need to update before the player to be able to pick up buffered jump/dash inputs
 			AddTag(Tags.FrozenUpdate);
+			Add(new FreezeUpdateHook(UpdatePress)); // update during freezeframes
 		}
 
 		public override void Update()
 		{
 			base.Update();
 
-			var pressed = false;
+			UpdatePress();
+		}
+
+		private void UpdatePress()
+		{
+			bool pressed = false;
 
 			switch (inputType)
 			{
-				case Types.Grab: pressed = Input.Grab.Pressed; wasPressed = false; break;
-				case Types.Jump: pressed = Input.Jump.Pressed; break;
-				case Types.Dash: pressed = Input.Dash.Pressed || Input.CrouchDash.Pressed; break;
-				case Types.Custom: pressed = EeveeHelperModule.Settings.ActivateCustomInputBlock.Pressed; wasPressed = false; break;
+				case Types.Grab:   pressed = Input.Grab.Pressed; break;
+				case Types.Jump:   pressed = Input.Jump.Pressed; break;
+				case Types.Dash:   pressed = Input.Dash.Pressed || (Settings.Instance.CrouchDashMode == CrouchDashModes.Press && Input.CrouchDash.Pressed); break;
+				case Types.Custom: pressed = EeveeHelperModule.Settings.ActivateCustomInputBlock.Pressed; break;
 			}
 
 			if (pressed && !wasPressed)
-			{
 				presses++;
-			}
 
 			wasPressed = pressed;
 		}
 
 		public bool ConsumePress(bool cancellable)
 		{
-			var pressed = cancellable ? presses % 2 == 1 : presses > 0;
+			bool pressed = cancellable ? presses % 2 == 1 : presses > 0;
 
 			presses = 0;
 

--- a/everest.yaml
+++ b/everest.yaml
@@ -3,7 +3,7 @@
   DLL: Code/bin/EeveeHelper.dll
   Dependencies:
     - Name: Everest
-      Version: 1.4465.0
+      Version: 1.5577.0
   OptionalDependencies:
     - Name: AdventureHelper
       Version: 1.5.1


### PR DESCRIPTION
Makes the `InputListener` for input toggle blocks update during freezeframes using a new `FreezeUpdateHook` component. Previously, inputs that occurred during freezeframes were ignored completely (and buffered inputs didn't work correctly either).

This also adjusts its depth to allow registering buffered jump/dash inputs, and disables buffering on the button binding for custom type blocks (since if buffered it was being automatically consumed, resulting in only the first updating input toggle block moving).