### PR TITLE
Add ModInterop for adding ignored anchor fields

### DIFF
--- a/Code/Components/EntityContainerMover.cs
+++ b/Code/Components/EntityContainerMover.cs
@@ -19,6 +19,8 @@ public class EntityContainerMover : EntityContainer
 	{
 		"Position", "ExactPosition", "TopLeft", "TopCenter", "TopRight", "Center", "CenterLeft", "CenterRight", "BottomLeft", "BottomCenter", "BottomRight"
 	};
+	private static Dictionary<Type, HashSet<string>> IgnoredAnchorsPerType = new();
+	
 	private static HashSet<string> CommonAnchors = new()
 	{
 		"anchor", "anchorPosition", "start", "startPosition"
@@ -273,12 +275,23 @@ public class EntityContainerMover : EntityContainer
 		var data = new InheritedDynData(entity);
 		foreach (var pair in data)
 		{
-			if (pair.Value is Vector2 vector && !IgnoredAnchors.Contains(pair.Key) && (vector == EeveeUtils.GetPosition(entity) || CommonAnchors.Contains(pair.Key)))
+			if (pair.Value is Vector2 vector
+				&& !IgnoredAnchors.Contains(pair.Key)
+				&& !(IgnoredAnchorsPerType.TryGetValue(entity.GetType(), out var ignoredAnchors) && ignoredAnchors.Contains(pair.Key))
+				&& (vector == EeveeUtils.GetPosition(entity) || CommonAnchors.Contains(pair.Key)))
 			{
 				result.Add(pair.Key);
 			}
 		}
 		return result;
+	}
+
+	public static void AddIgnoredAnchors(Type type, HashSet<string> anchors)
+	{
+		if (IgnoredAnchorsPerType.TryGetValue(type, out var alreadyIgnoredAnchors))
+			alreadyIgnoredAnchors.UnionWith(anchors);
+		else
+			IgnoredAnchorsPerType.Add(type, anchors);
 	}
 
 	public static void AddEntityHandler(Type entityType, Type handlerType)

--- a/Code/Components/EntityContainerMover.cs
+++ b/Code/Components/EntityContainerMover.cs
@@ -5,6 +5,7 @@ using Monocle;
 using MonoMod.Utils;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Celeste.Mod.EeveeHelper.Components;
 
@@ -273,11 +274,12 @@ public class EntityContainerMover : EntityContainer
 	{
 		var result = new List<string>();
 		var data = new InheritedDynData(entity);
+		var type = entity.GetType();
 		foreach (var pair in data)
 		{
 			if (pair.Value is Vector2 vector
 				&& !IgnoredAnchors.Contains(pair.Key)
-				&& (!IgnoredAnchorsPerType.TryGetValue(entity.GetType(), out var ignoredAnchors) || !ignoredAnchors.Contains(pair.Key))
+				&& IgnoredAnchorsPerType.All(kvp => !kvp.Key.IsAssignableFrom(type) || !kvp.Value.Contains(pair.Key))
 				&& (vector == EeveeUtils.GetPosition(entity) || CommonAnchors.Contains(pair.Key)))
 			{
 				result.Add(pair.Key);

--- a/Code/Components/EntityContainerMover.cs
+++ b/Code/Components/EntityContainerMover.cs
@@ -277,7 +277,7 @@ public class EntityContainerMover : EntityContainer
 		{
 			if (pair.Value is Vector2 vector
 				&& !IgnoredAnchors.Contains(pair.Key)
-				&& !(IgnoredAnchorsPerType.TryGetValue(entity.GetType(), out var ignoredAnchors) && ignoredAnchors.Contains(pair.Key))
+				&& (!IgnoredAnchorsPerType.TryGetValue(entity.GetType(), out var ignoredAnchors) || !ignoredAnchors.Contains(pair.Key))
 				&& (vector == EeveeUtils.GetPosition(entity) || CommonAnchors.Contains(pair.Key)))
 			{
 				result.Add(pair.Key);

--- a/Code/Components/EntityContainerMover.cs
+++ b/Code/Components/EntityContainerMover.cs
@@ -274,16 +274,17 @@ public class EntityContainerMover : EntityContainer
 	{
 		var result = new List<string>();
 		var data = new InheritedDynData(entity);
+		
 		var type = entity.GetType();
+		var ignoredAnchorsForType = IgnoredAnchorsPerType.SelectMany(kvp => kvp.Key.IsAssignableFrom(type) ? kvp.Value : []).ToArray();
+		
 		foreach (var pair in data)
 		{
 			if (pair.Value is Vector2 vector
 				&& !IgnoredAnchors.Contains(pair.Key)
-				&& IgnoredAnchorsPerType.All(kvp => !kvp.Key.IsAssignableFrom(type) || !kvp.Value.Contains(pair.Key))
+				&& !ignoredAnchorsForType.Contains(pair.Key)
 				&& (vector == EeveeUtils.GetPosition(entity) || CommonAnchors.Contains(pair.Key)))
-			{
 				result.Add(pair.Key);
-			}
 		}
 		return result;
 	}

--- a/Code/EeveeHelper.csproj
+++ b/Code/EeveeHelper.csproj
@@ -1,17 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <AssemblyName>EeveeHelper</AssemblyName>
         <RootNamespace>Celeste.Mod.EeveeHelper</RootNamespace>
         <LangVersion>latest</LangVersion>
         <CelestePrefix Condition="'$(CelestePrefix)' == '' And Exists('..\..\Celeste.dll')">..\..</CelestePrefix>
         <CelestePrefix Condition="'$(CelestePrefix)' == '' And Exists('..\..\..\Celeste.dll')">..\..\..</CelestePrefix>
         <CelestePrefix Condition="'$(CelestePrefix)' == ''">lib-stripped</CelestePrefix>
-
-        <CelesteType Condition="'$(CelesteType)' == '' And Exists('$(CelestePrefix)\BuildIsXNA.txt')">XNA</CelesteType>
-        <CelesteType Condition="'$(CelesteType)' == ''">FNA</CelesteType>
-        <XNAPath Condition="'$(XNAPath)' == ''">$(WINDIR)\Microsoft.NET\assembly\GAC_32\{0}\v4.0_4.0.0.0__842cf8be1de50553\{0}.dll</XNAPath>
     </PropertyGroup>
 
     <!--Disable "Copy Local" for all references-->
@@ -21,31 +17,20 @@
     </ItemDefinitionGroup>
 
     <ItemGroup>
-        <PackageReference Include="MonoMod.RuntimeDetour" Version="22.01.04.03" />
-        <PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.1" PrivateAssets="all" />
+        <PackageReference Include="MonoMod.RuntimeDetour" Version="25.3.1" PrivateAssets="all" ExcludeAssets="runtime" />
+        <PackageReference Include="MonoMod.Patcher" Version="25.0.0-prerelease.2" />
+        <PackageReference Include="CelesteAnalyzer" Version="*" />
     </ItemGroup>
 
     <ItemGroup>
-        <Reference Include="$(CelestePrefix)\Celeste.dll" Publicize="true" />
-        <Reference Include="$(CelestePrefix)\MMHOOK_Celeste.dll" />
+        <PackageReference Include="CelesteMod.Publicizer" Version="*" CelesteAssembly="$(CelestePrefix)\Celeste.dll" />
+        <Reference Include="$(CelestePrefix)\MMHOOK_Celeste.dll" Private="false" />
+        <Reference Include="$(CelestePrefix)\FNA.dll" Private="false" />
+    </ItemGroup>
+    
+    <ItemGroup>
         <Reference Include="lib-stripped\StyleMaskHelper.dll" />
     </ItemGroup>
-
-    <Choose>
-        <When Condition="'$(CelesteType)' == 'FNA'">
-            <ItemGroup>
-                <Reference Include="$(CelestePrefix)\FNA.dll" />
-            </ItemGroup>
-        </When>
-
-        <When Condition="'$(CelesteType)' == 'XNA'">
-            <ItemGroup>
-                <Reference Include="$([System.String]::Format('$(XNAPath)', 'Microsoft.Xna.Framework'))" />
-                <Reference Include="$([System.String]::Format('$(XNAPath)', 'Microsoft.Xna.Framework.Game'))" />
-                <Reference Include="$([System.String]::Format('$(XNAPath)', 'Microsoft.Xna.Framework.Graphics'))" />
-            </ItemGroup>
-        </When>
-    </Choose>
 
     <Target Name="CopyFiles" AfterTargets="Build">
         <Copy SourceFiles="$(OutputPath)\$(AssemblyName).dll" DestinationFolder="bin" />

--- a/Code/EeveeHelperModule.cs
+++ b/Code/EeveeHelperModule.cs
@@ -4,6 +4,7 @@ using Celeste.Mod.EeveeHelper.Entities;
 using Celeste.Mod.EeveeHelper.Handlers;
 using Celeste.Mod.EeveeHelper.Handlers.Impl;
 using Monocle;
+using MonoMod.ModInterop;
 using System;
 using System.Collections.Generic;
 
@@ -31,6 +32,8 @@ public class EeveeHelperModule : EverestModule
 
 	public override void Load()
 	{
+		typeof(Exports).ModInterop();
+		
 		MiscHooks.Load();
 		RoomChest.Load();
 		HoldableTiles.Load();

--- a/Code/Exports.cs
+++ b/Code/Exports.cs
@@ -1,0 +1,13 @@
+using Celeste.Mod.EeveeHelper.Components;
+using MonoMod.ModInterop;
+using System;
+using System.Collections.Generic;
+
+namespace Celeste.Mod.EeveeHelper;
+
+[ModExportName("EeveeHelper")]
+public static class Exports
+{
+	public static void RegisterIgnoredAnchors(Type forType, HashSet<string> fieldNames)
+		=> EntityContainerMover.AddIgnoredAnchors(forType, fieldNames);
+}

--- a/Code/InheritedDynData.cs
+++ b/Code/InheritedDynData.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 
 namespace Celeste.Mod.EeveeHelper;

--- a/Code/InheritedDynData.cs
+++ b/Code/InheritedDynData.cs
@@ -82,6 +82,8 @@ public sealed class InheritedDynData : IDisposable, IEnumerable<KeyValuePair<str
 
 	public object Set(string name, object value)
 	{
+		Logger.Debug(nameof(EeveeHelper), $"setting '{name}' = {value}");
+		
 		foreach (var data in _Data)
 		{
 			if (data.TryGet(name, out _))

--- a/Code/InheritedDynData.cs
+++ b/Code/InheritedDynData.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 
 namespace Celeste.Mod.EeveeHelper;
@@ -82,8 +83,6 @@ public sealed class InheritedDynData : IDisposable, IEnumerable<KeyValuePair<str
 
 	public object Set(string name, object value)
 	{
-		Logger.Debug(nameof(EeveeHelper), $"setting '{name}' = {value}");
-		
 		foreach (var data in _Data)
 		{
 			if (data.TryGet(name, out _))


### PR DESCRIPTION
Currently, entity containers check against every field in all base classes of a contained entity for "anchors" (fields which happen to have the same value as the entity's `Position`) which it assumes are meant to always hold the `Position` of the entity, and will update them accordingly. This is obviously not always the case, so this PR adds ModInterop to support excluding fields from being anchors. The current implementation respects inheritance, so excluding a field on a base class will also automatically exclude it on any derived classes.